### PR TITLE
Add Python personal finance manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# Sistema-de-finanzas-personales
-Gestionar finanzas
+# Sistema de Finanzas Personales
+
+Aplicación simple escrita en Python para registrar ingresos y gastos, y obtener un balance y resumen por categoría.
+
+## Uso
+
+```bash
+python main.py ingreso 1000 salario --descripcion "Pago mensual"
+python main.py gasto 200 comida --descripcion "Cena"
+python main.py balance
+python main.py resumen
+```
+
+Los datos se guardan en `finanzas.json` en el directorio actual.
+
+## Pruebas
+
+Ejecuta las pruebas con:
+
+```bash
+pytest
+```

--- a/finance_manager.py
+++ b/finance_manager.py
@@ -1,0 +1,55 @@
+import json
+from dataclasses import dataclass, asdict
+from datetime import date
+from typing import List
+
+
+@dataclass
+class Transaction:
+    amount: float
+    category: str
+    description: str = ""
+    date: str = date.today().isoformat()
+
+
+class FinanceManager:
+    """Simple personal finance manager with JSON persistence."""
+
+    def __init__(self, filepath: str = "finanzas.json") -> None:
+        self.filepath = filepath
+        self.transactions: List[Transaction] = []
+        self.load()
+
+    def load(self) -> None:
+        """Load transactions from JSON file."""
+        try:
+            with open(self.filepath, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.transactions = [Transaction(**t) for t in data]
+        except FileNotFoundError:
+            self.transactions = []
+
+    def save(self) -> None:
+        """Persist transactions to JSON file."""
+        with open(self.filepath, "w", encoding="utf-8") as f:
+            json.dump([asdict(t) for t in self.transactions], f, ensure_ascii=False, indent=2)
+
+    def add_income(self, amount: float, category: str, description: str = "") -> None:
+        self.transactions.append(Transaction(amount, category, description))
+        self.save()
+
+    def add_expense(self, amount: float, category: str, description: str = "") -> None:
+        self.transactions.append(Transaction(-abs(amount), category, description))
+        self.save()
+
+    def balance(self) -> float:
+        return sum(t.amount for t in self.transactions)
+
+    def summary_by_category(self) -> dict:
+        summary: dict[str, float] = {}
+        for t in self.transactions:
+            summary[t.category] = summary.get(t.category, 0.0) + t.amount
+        return summary
+
+    def list_transactions(self) -> List[Transaction]:
+        return list(self.transactions)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,41 @@
+import argparse
+from finance_manager import FinanceManager
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sistema de finanzas personales")
+    parser.add_argument("--archivo", default="finanzas.json", help="Archivo de datos")
+
+    subparsers = parser.add_subparsers(dest="comando")
+
+    p_ingreso = subparsers.add_parser("ingreso", help="Registrar un ingreso")
+    p_ingreso.add_argument("monto", type=float)
+    p_ingreso.add_argument("categoria")
+    p_ingreso.add_argument("--descripcion", default="")
+
+    p_gasto = subparsers.add_parser("gasto", help="Registrar un gasto")
+    p_gasto.add_argument("monto", type=float)
+    p_gasto.add_argument("categoria")
+    p_gasto.add_argument("--descripcion", default="")
+
+    subparsers.add_parser("balance", help="Mostrar balance actual")
+    subparsers.add_parser("resumen", help="Mostrar resumen por categoria")
+
+    args = parser.parse_args()
+    fm = FinanceManager(args.archivo)
+
+    if args.comando == "ingreso":
+        fm.add_income(args.monto, args.categoria, args.descripcion)
+    elif args.comando == "gasto":
+        fm.add_expense(args.monto, args.categoria, args.descripcion)
+    elif args.comando == "balance":
+        print(f"Balance: {fm.balance():.2f}")
+    elif args.comando == "resumen":
+        for categoria, monto in fm.summary_by_category().items():
+            print(f"{categoria}: {monto:.2f}")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_finance_manager.py
+++ b/tests/test_finance_manager.py
@@ -1,0 +1,14 @@
+from finance_manager import FinanceManager
+
+
+def test_income_and_expense(tmp_path):
+    datafile = tmp_path / "finanzas.json"
+    fm = FinanceManager(str(datafile))
+    fm.add_income(1000, "salario")
+    fm.add_expense(200, "comida")
+    assert fm.balance() == 800
+    resumen = fm.summary_by_category()
+    assert resumen["salario"] == 1000
+    assert resumen["comida"] == -200
+    fm2 = FinanceManager(str(datafile))
+    assert fm2.balance() == 800


### PR DESCRIPTION
## Summary
- implement `FinanceManager` with JSON storage for incomes, expenses and reporting
- provide command line interface for adding transactions and viewing balance
- document usage and testing instructions

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af15dee88c832785eec65d4a320828